### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ We also provide a [`justfile`](https://just.systems/) for Makefile'esque command
 
 ## See Also
 
-- [nixos.wiki: Packaging Rust projects with nix](https://wiki.nixos.org/wiki/Rust#Packaging_Rust_projects_with_nix)
+- [wiki.nixos.org: Packaging Rust projects with nix](https://wiki.nixos.org/wiki/Rust#Packaging_Rust_projects_with_nix)


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️